### PR TITLE
Include xml id tag in plugin metadata

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -11,6 +11,7 @@
   -->
 
 <idea-plugin>
+    <id>de.halirutan</id>
     <name>Key Promoter X</name>
     <vendor>halirutan</vendor>
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
Include xml id tag in plugin metadata to make it identifiable by automation tools.