### PR TITLE
Pin IntelliJ Platform Gradle Plugin to stable latest version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,9 +22,10 @@ dependencies {
     intellijPlatform {
         intellijIdea("2026.1")
         testFramework(TestFrameworkType.Platform)
-        // Verifier 1.385 introduced a reopenable JAR filesystem rework that crashes parallel
-        // verifyPlugin with java.nio.file.ClosedFileSystemException. Pin the last good release.
-        pluginVerifier("1.383")
+        // Pinned: unpinned resolves to latest. >=1.385 races on parallel verify
+        // (ClosedFileSystemException); <1.385 can't read 2026.x layout (false fails).
+        // 1.401 = last known-good.
+        pluginVerifier("1.401")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
-    id("org.jetbrains.intellij.platform") version "2.13.2-SNAPSHOT"
+    id("org.jetbrains.intellij.platform") version "2.16.0"
     id("org.jetbrains.changelog") version "2.5.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
-    id("org.jetbrains.intellij.platform") version "2.15.0"
+    id("org.jetbrains.intellij.platform") version "2.16.0"
     id("org.jetbrains.changelog") version "2.5.0"
 }
 
@@ -22,6 +22,9 @@ dependencies {
     intellijPlatform {
         intellijIdea("2026.1")
         testFramework(TestFrameworkType.Platform)
+        // Verifier 1.385 introduced a reopenable JAR filesystem rework that crashes parallel
+        // verifyPlugin with java.nio.file.ClosedFileSystemException. Pin the last good release.
+        pluginVerifier("1.384")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
         testFramework(TestFrameworkType.Platform)
         // Verifier 1.385 introduced a reopenable JAR filesystem rework that crashes parallel
         // verifyPlugin with java.nio.file.ClosedFileSystemException. Pin the last good release.
-        pluginVerifier("1.384")
+        pluginVerifier("1.383")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
-    id("org.jetbrains.intellij.platform") version "2.16.0"
+    id("org.jetbrains.intellij.platform") version "2.15.0"
     id("org.jetbrains.changelog") version "2.5.0"
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,6 @@ rootProject.name = "Key Promoter X"
 
 pluginManagement {
     repositories {
-        maven("https://central.sonatype.com/repository/maven-snapshots/")
         gradlePluginPortal()
     }
 }

--- a/src/de/halirutan/keypromoterx/KeyPromoterXStartupNotification.java
+++ b/src/de/halirutan/keypromoterx/KeyPromoterXStartupNotification.java
@@ -23,7 +23,7 @@
 package de.halirutan.keypromoterx;
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.DumbAware;
@@ -46,7 +46,7 @@ public class KeyPromoterXStartupNotification implements ProjectActivity, DumbAwa
     final KeyPromoterSettings settings = ApplicationManager.getApplication().getService(KeyPromoterSettings.class);
     final String installedVersion = settings.getInstalledVersion();
 
-    final IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.getId("Key Promoter X"));
+    final IdeaPluginDescriptor plugin = PluginManager.getInstance().findEnabledPlugin(PluginId.getId("Key Promoter X"));
     if (installedVersion != null && plugin != null) {
       final int compare = VersionComparatorUtil.compare(installedVersion, plugin.getVersion());
 //      if (true) { // TODO: Don't forget to remove that! For proofreading.


### PR DESCRIPTION
Replace the 2.13.2-SNAPSHOT dependency with the latest version (2.16.0) and remove the unused snapshots repo.

Note: 2.16.0 bundles a faulty plugin verifier and, hence, the plugin verifier is pinned for now.